### PR TITLE
Specified scripts in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
     - "node"
+script:
+- npm run lint
+- npm test
+- npm run build

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "standard && react-scripts test",
-    "eject": "react-scripts eject"
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "lint": "standard"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
By default TravisCI runs `npm test` for node_js projects but in preparation of using Travis to also deploy we need to both run `npm test` as well as `npm build`.
While I'm at it I figured I'd split the linting test from the unit tests as they are checking separate things and we'd like to run unit tests even if linting fails to see if it's the only thing that needs to change before we can merge and deploy.